### PR TITLE
Remove broken hero image link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # MapNJ
 
-![MapNJ Screenshot](https://mapnj.masa-sumimoto.com/public/readme-hero.png)
-
 ![npm version](https://img.shields.io/npm/v/mapnj.svg?color=red)
 ![NPM Downloads](https://img.shields.io/npm/dt/mapnj.svg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
The hero image URL (https://mapnj.masa-sumimoto.com/public/readme-hero.png) has been 404 since the docs site's image reorganization in April 2026. Removing the line so the npm/GitHub README doesn't show a broken image; a new hero can be added later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)