### PR TITLE
chore: normalize repository.url (npm pkg fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/masa-sumimoto/mapnj.git"
+    "url": "git+https://github.com/masa-sumimoto/mapnj.git"
   },
   "bugs": {
     "url": "https://github.com/masa-sumimoto/mapnj/issues"


### PR DESCRIPTION
One-liner: `repository.url` → `git+https://...` form, as suggested by the `npm publish` warning during the 1.0.0 release. No functional change; takes effect in the next publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)